### PR TITLE
Refactoring manager for ease testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ on, you can use the [UNICORN Binance REST API](https://www.lucit.tech/unicorn-bi
 | [Binance JEX](https://www.jex.com)                                 | `jex.com` |
 | [Binance DEX](https://www.binance.org)                             | `binance.org` |
 | [Binance DEX Testnet](https://testnet.binance.org)                 | `binance.org-testnet` |
+| Localhost                                                          | `localhost`                           |
 
 - Streams are processing asynchronous/concurrent (Python asyncio) and each stream is started in a separate thread, so 
 you dont need to deal with asyncio in your code!

--- a/unicorn_binance_websocket_api/ws_connection_settings.py
+++ b/unicorn_binance_websocket_api/ws_connection_settings.py
@@ -1,0 +1,59 @@
+from enum import Enum
+from typing import Tuple
+
+
+WEBSOCKET_BASE_URI = str
+MAX_SUBSCRIPTIONS_PER_STREAM = int
+
+
+class Exchanges(str, Enum):
+    BINANCE = "binance.com"
+    BINANCE_TESTNET = "binance.com-testnet"
+    BINANCE_MARGIN = "binance.com-margin"
+    BINANCE_MARGIN_TESTNET = "binance.com-margin-testnet"
+    BINANCE_ISOLATED_MARGIN = "binance.com-isolated_margin"
+    BINANCE_ISOLATED_MARGIN_TESTNET = "binance.com-isolated_margin-testnet"
+    BINANCE_FUTURES = "binance.com-futures"
+    BINANCE_COIN_FUTURES = "binance.com-coin-futures"
+    BINANCE_FUTURES_TESTNET = "binance.com-futures-testnet"
+    BINANCE_US = "binance.us"
+    TRBINANCE = "trbinance.com"
+    JEX = "jex.com"
+    BINANCE_ORG = "binance.org"
+    BINANCE_ORG_TESTNET = "binance.org-testnet"
+    LOCALHOST = "localhost"
+
+
+DEX_EXCHANGES = [Exchanges.BINANCE_ORG, Exchanges.BINANCE_ORG_TESTNET]
+CEX_EXCHANGES = [
+    Exchanges.BINANCE,
+    Exchanges.BINANCE_TESTNET,
+    Exchanges.BINANCE_MARGIN,
+    Exchanges.BINANCE_MARGIN_TESTNET,
+    Exchanges.BINANCE_ISOLATED_MARGIN,
+    Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET,
+    Exchanges.BINANCE_FUTURES,
+    Exchanges.BINANCE_COIN_FUTURES,
+    Exchanges.BINANCE_FUTURES_TESTNET,
+    Exchanges.BINANCE_US,
+    Exchanges.TRBINANCE,
+    Exchanges.JEX,
+]
+
+ws_connection_settings: dict[str, Tuple[WEBSOCKET_BASE_URI, MAX_SUBSCRIPTIONS_PER_STREAM]] = {
+    Exchanges.BINANCE: ("wss://stream.binance.com:9443/", 1024),
+    Exchanges.BINANCE_TESTNET: ("wss://testnet.binance.vision/", 1024),
+    Exchanges.BINANCE_MARGIN: ("wss://stream.binance.com:9443/", 1024),
+    Exchanges.BINANCE_MARGIN_TESTNET: ("wss://testnet.binance.vision/", 1024),
+    Exchanges.BINANCE_ISOLATED_MARGIN: ("wss://stream.binance.com:9443/", 1024),
+    Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET: ("wss://testnet.binance.vision/", 1024),
+    Exchanges.BINANCE_FUTURES: ("wss://fstream.binance.com/", 200),
+    Exchanges.BINANCE_COIN_FUTURES: ("wss://dstream.binance.com/", 200),
+    Exchanges.BINANCE_FUTURES_TESTNET: ("wss://stream.binancefuture.com/", 200),
+    Exchanges.BINANCE_US: ("wss://stream.binance.us:9443/", 1024),
+    Exchanges.TRBINANCE: ("wss://stream-cloud.trbinance.com/", 1024),
+    Exchanges.JEX: ("wss://ws.jex.com/", 10),
+    Exchanges.BINANCE_ORG: ("wss://dex.binance.org/api/", 1024),
+    Exchanges.BINANCE_ORG_TESTNET: ("wss://testnet-dex.binance.org/api/", 1024),
+    Exchanges.LOCALHOST: ("ws://127.0.0.1:8765/", 1024),
+}


### PR DESCRIPTION
# PR Details

I made a more flexible `manager` constructor so that you can replace the exchange with your own mock server.

## Description

To replace the exchange with your mock server, just specify `exchange=Exchanges.LOCALHOST, exchange_type='dex'` (or `cex`) when initializing the manager. `exchange_type` must be specified only for `Localhost`. You can also set `websocket_base_uri` and `max_subscriptions_per_stream` otherwise the default values ​​will be applied.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://github.com/LUCIT-Systems-and-Development/unicorn-binance-websocket-api/issues/304

## Motivation and Context

With the previous implementation - replacing the server with your own mock - was unreal.

## How Has This Been Tested

Tested on localhost (MacOS) and in docker. I worked with a real exchange and with my own mock server.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/LUCIT-Systems-and-Development/unicorn-binance-websocket-api/blob/master/CONTRIBUTING.md)** 
document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
